### PR TITLE
Removed start and stop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ app.listen(1337);
 ```
 
 You can now test by going to `http://localhost:1337/_ah/health`
+
+### Notes
+
+App Engine Flex only supports `/_ah/health` at this time - you should not process, or handle `/_ah/start` or `/_ah/stop` via your application code.

--- a/index.js
+++ b/index.js
@@ -10,15 +10,4 @@ router.get('/_ah/health', function(req, res) {
     res.status(200).send('ok');
 });
 
-router.get('/_ah/start', function(req, res) {
-    res.set('Content-Type', 'text/plain');
-    res.status(200).send('ok');
-});
-
-router.get('/_ah/stop', function(req, res) {
-    res.set('Content-Type', 'text/plain');
-    res.status(200).send('ok');
-    process.exit();
-});
-
 module.exports = router;

--- a/test.js
+++ b/test.js
@@ -17,18 +17,4 @@ describe('App Engine Handlers', function() {
             .expect('Content-Type', 'text/plain; charset=utf-8')
             .expect(200, 'ok', done);
     });
-
-    it('handles the start request properly', function(done) {
-        request(app)
-            .get('/_ah/start')
-            .expect('Content-Type', 'text/plain; charset=utf-8')
-            .expect(200, 'ok', done);
-    });
-
-    it('handles the stop request properly', function(done) {
-        request(app)
-            .get('/_ah/stop')
-            .expect('Content-Type', 'text/plain; charset=utf-8')
-            .expect(200, 'ok', done);
-    });
 });


### PR DESCRIPTION
App Engine Flex applications should not accept start and stop requests.
They are not filtered by the platform - thus people can stop (restart) apps by calling this (now) public URL.

Per Google:

> According to Flex backend team, /_ah/start and /_ah/stop calls are not supported in env:flex applications.
> Some of the flex documentations still have incorrect description for this and our team is working to fix it.
>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/homezen/express-appengine-handlers/17)
<!-- Reviewable:end -->
